### PR TITLE
Bump verilator version from 5.034 to 5.042

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -297,8 +297,8 @@ jobs:
       - name: Setup tools
         if: steps.cache-dir.outputs.cache-hit != 'true'
         run: |
-          wget -q https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2025-04-24/oss-cad-suite-linux-x64-20250424.tgz
-          tar xf oss-cad-suite-linux-x64-20250424.tgz
+          wget -q https://github.com/YosysHQ/oss-cad-suite-build/releases/download/2025-11-24/oss-cad-suite-linux-x64-20251124.tgz
+          tar xf oss-cad-suite-linux-x64-20251124.tgz
           OSS_CAD_SUITE_BIN_PATH=`pwd`/oss-cad-suite/bin
           echo "PATH=$PATH:$OSS_CAD_SUITE_BIN_PATH" >> $GITHUB_ENV
 


### PR DESCRIPTION
Verilator released a new stable version 5.042 in 2025-11-02 which caused some minor structural changes in the verilated model. Though handouts doesn't encourage usage of `rootp` in the model to access internal state of the circuit (for difftest etc.). Some students still use it.  After this update some TA  reported that student code which pass CI can't be compiled in their environment. Since the `“一生一芯”【B阶段结业考核】申请指引`  require usage of  latest stable version of verilator. The verilator version in CI should be updated.

---

By the way, what purpose does the `cache-dir` in CI serves? Seems the cache can never hit since the time is used as key. I can't figure any situation this cache can hit.