### PR TITLE
修复面积检查因shell比较不支持浮点数导致全部通过

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -619,8 +619,8 @@ jobs:
         run: |
           AREA_BUDGET=16500
           AREA_OLD_BUDGET=25000
-          if [[ $AREA -gt $AREA_BUDGET ]] ; then
-            if [[ $AREA_OLD -gt $AREA_OLD_BUDGET ]] ; then
+          if [ $(awk "BEGIN {print ($AREA > $AREA_BUDGET)}") -eq 1 ]; then
+            if [ $(awk "BEGIN {print ($AREA_OLD > $AREA_OLD_BUDGET)}") -eq 1 ]; then
               echo "Area($AREA) is larger than the budget($AREA_BUDGET)."
               echo "Area for old version of yosys-sta($AREA_OLD) is larger than the budget($AREA_OLD_BUDGET)."
               false


### PR DESCRIPTION
原先在执行
```
[[ -gt
```
时报错导致所有面积检查均通过
```
 [[: 36235.584000: syntax error: invalid arithmetic operator (error token is ".584000")
```
修复：使用awk对浮点数进行比较