### PR TITLE
fix new version mill require .mill-version when call mill --version

### DIFF
--- a/.github/workflows/autotest.yml
+++ b/.github/workflows/autotest.yml
@@ -276,6 +276,11 @@ jobs:
           fi
           echo "Downloading mill with version $MILL_VERSION"
           sh -c "curl -L https://github.com/com-lihaoyi/mill/releases/download/$MILL_VERSION/$MILL_VERSION > ~/.local/bin/mill && chmod +x ~/.local/bin/mill"
+
+          if [[ -e $YSYX_HOME/npc/.mill-version ]]; then
+            # new version mill --version requires pwd has .mill-version file
+            cd $YSYX_HOME/npc
+          fi
           mill --version
 
       - name: Get ysyxSoC tag


### PR DESCRIPTION
新版本的 mill --version 需要设置当前工作目录下的 .mill-version 文件或者其他方式在文件中指定，不然会报错
```
No mill version specified.
You should provide a version via '.mill-version' file or --mill-version option.
find: ‘/home/runner/.cache/mill/download/.latest’: No such file or directory
Retrieving latest mill version ...
Using mill version 1.1.5
Downloading mill 1.1.5 from https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.1.5/mill-dist-1.1.5.jar ...
```
然后下载最新版本的 mill
但是出于未知原因，在ci环境下获取到的连接 <https://repo1.maven.org/maven2/com/lihaoyi/mill-dist/1.1.5/mill-dist-1.1.5.jar> 是404

不过没有找到究竟是哪个版本开始有的这个特性，至少 0.12.4 会出现这个问题

---

修复方法是如果学员有指定 .mill-version 就去 npc 目录下执行 mill --version，否则还是直接mill --version 保持默认行为